### PR TITLE
adding error field to decode any OAuth error from server

### DIFF
--- a/dropbox/dropbox.go
+++ b/dropbox/dropbox.go
@@ -27,6 +27,7 @@ type Token struct {
     // API call to Dropbox CORE API.
     // https://www.dropbox.com/developers/core/docs
     Token string `json:"access_token"`
+	Error *string `json:"error"`
 }
 
 type OAuth2Handler struct {


### PR DESCRIPTION
adding Error field so that when dropbox returns error it gets populated in this field

https://www.dropbox.com/developers-v1/core/docs#oa2-authorize
